### PR TITLE
Update sight bob values and correct scopes

### DIFF
--- a/zscript/accensus/weapons/Blackjack/blackjack.zs
+++ b/zscript/accensus/weapons/Blackjack/blackjack.zs
@@ -157,7 +157,7 @@ class HDBlackjack : HDWeapon
 		int cx, cy, cw, ch;
 		[cx, cy, cw, ch] = Screen.GetClipRect();
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 12, sb.DI_SCREEN_CENTER);
-		vector2 bob2 = bob * 2;
+		vector2 bob2 = bob * 1.14;
 		bob2.y = clamp(bob2.y, -8, 8);
 		sb.DrawImage("BJCKFRNT", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9, scale: (0.8, 0.6));
 		sb.SetClipRect(cx, cy, cw, ch);

--- a/zscript/accensus/weapons/Gungnir/gungnir.zs
+++ b/zscript/accensus/weapons/Gungnir/gungnir.zs
@@ -348,7 +348,7 @@ class HDGungnir : HDCellWeapon
 		int cx, cy, cw, ch;
 		[cx, cy, cw, ch] = Screen.GetClipRect();
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 16, sb.DI_SCREEN_CENTER);
-		vector2 bobb = bob * 2;
+		vector2 bobb = bob * 1.14;
 		bobb.y = clamp(bobb.y, -8, 8);
 		sb.DrawImage("GNGRFRNT", bobb, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9);
 		sb.SetClipRect(cx, cy, cw, ch);
@@ -367,7 +367,6 @@ class HDGungnir : HDCellWeapon
 			let cam  = texman.CheckForTexture("HDXCAM_BOSS",TexMan.Type_Any);
 			sb.DrawCircle(cam,(0,scaledyoffset)+bob*3,.11,usePixelRatio:true);
 
-			sb.DrawImage("HDXCAM_BOSS", (0, ScaledYOffset) + bob, sb.DI_SCREEN_CENTER |  sb.DI_ITEM_CENTER, scale: ScaleHalf);
 			sb.DrawImage("SCOPHOLE", (0, ScaledYOffset) + bob * 5, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, scale: (1.5, 1.5));
 			Screen.SetClipRect(cx, cy, cw, ch);
 			sb.DrawImage("GNRSCOPE", (0, ScaledYOffset) + bob, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, scale: (1.24, 1.24));

--- a/zscript/accensus/weapons/Hammerhead/hammerhead.zs
+++ b/zscript/accensus/weapons/Hammerhead/hammerhead.zs
@@ -147,10 +147,10 @@ class HDHammerhead : HDCellWeapon
 	override void DrawSightPicture(HDStatusBar sb, HDWeapon hdw, HDPlayerPawn hpl, bool sightbob, vector2 bob, double fov, bool scopeview, actor hpc, string whichdot)
 	{
 		double dotoff = max(abs(bob.x), abs(bob.y));
-		if (dotoff < 6)
+		if (dotoff < 40)
 		{
 			string whichdot = sb.ChooseReflexReticle(WeaponStatus[HHProp_Dot]);
-			sb.DrawImage(whichdot, (0, 0) + bob * 3, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, alpha: 0.8 - dotoff * 0.04, col: 0xFF000000 | sb.crosshaircolor.GetInt());
+			sb.DrawImage(whichdot, (0, 0) + bob * 1.1, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, alpha: 0.8 - dotoff * 0.01, col: 0xFF000000 | sb.crosshaircolor.GetInt());
 		}
 
 		sb.DrawImage("HAMRSITE", (0, 0) + bob, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER);

--- a/zscript/accensus/weapons/Jackdaw/jackdaw.zs
+++ b/zscript/accensus/weapons/Jackdaw/jackdaw.zs
@@ -57,7 +57,7 @@ class HDJackdaw : HDWeapon
 		int cx, cy, cw, ch;
 		[cx, cy, cw, ch] = Screen.GetClipRect();
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 16, sb.DI_SCREEN_CENTER);
-		vector2 bob2 = bob * 2;
+		vector2 bob2 = bob * 1.14;
 		bob2.y = clamp(bob2.y, -8, 8);
 		sb.DrawImage("JDWFRONT", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9);
 		sb.SetClipRect(cx, cy, cw, ch);

--- a/zscript/accensus/weapons/Majestic/majestic.zs
+++ b/zscript/accensus/weapons/Majestic/majestic.zs
@@ -180,7 +180,7 @@ class HDMajestic : HDHandgun
 		int cx, cy, cw, ch;
 		[cx, cy, cw, ch] = Screen.GetClipRect();
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 13, sb.DI_SCREEN_CENTER);
-		vector2 bob2 = bob * 2;
+		vector2 bob2 = bob * 1.14;
 		bob2.y = clamp(bob2.y, -8, 8);
 		sb.DrawImage("MJTCFRNT", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9, scale: (0.8, 0.6));
 		sb.SetClipRect(cx, cy, cw, ch);

--- a/zscript/accensus/weapons/Redline/redline.zs
+++ b/zscript/accensus/weapons/Redline/redline.zs
@@ -125,7 +125,7 @@ class HDRedline : HDCellWeapon
 	override void DrawSightPicture(HDStatusBar sb, HDWeapon hdw, HDPlayerPawn hpl, bool sightbob, vector2 bob, double fov, bool scopeview, actor hpc, string whichdot)
 	{
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 16, sb.DI_SCREEN_CENTER);
-		vector2 bob2 = bob * 2;
+		vector2 bob2 = bob * 1.14;
 		bob2.y = clamp(bob2.y, -8, 8);
 		sb.DrawImage("REDFRONT", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9);
 		sb.ClearClipRect();
@@ -134,22 +134,21 @@ class HDRedline : HDCellWeapon
 		if (scopeview)
 		{
 			//fixed courtesy of TooFewSecrets from Discord
-		
+
 			int scaledyoffset=76;
 			int scaledwidth=91;
 			int cx,cy,cw,ch;
 			[cx,cy,cw,ch]=screen.GetClipRect();
 			sb.SetClipRect(-45.5 + bob.x, 30.5 + bob.y, scaledwidth, scaledwidth, sb.DI_SCREEN_CENTER);
-			
+
 			texman.setcameratotexture(hpc, "HDXCAM_ZM66", 5);
 			let cam  = texman.CheckForTexture("HDXCAM_ZM66",TexMan.Type_Any);
-			sb.DrawCircle(cam,(0,ScaledYOffset)+bob*3,.11,usePixelRatio:true);
+			sb.DrawCircle(cam,(0,ScaledYOffset)+bob*3,.15,usePixelRatio:true);
 
-			sb.DrawImage("HDXCAM_ZM66", (0, scaledyoffset) + bob, sb.DI_SCREEN_CENTER |  sb.DI_ITEM_CENTER, scale: (.5, .5));
 			sb.DrawImage("SCOPHOLE", (0, scaledyoffset) + bob * 5, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, scale: (1.5, 1.5));
 			Screen.SetClipRect(cx, cy, cw, ch);
 			sb.DrawImage("RDLNSCOP", (0, scaledyoffset) + bob, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, scale: (1.25, 1.25));
-			
+
 		}
 	}
 

--- a/zscript/accensus/weapons/Viper/viper.zs
+++ b/zscript/accensus/weapons/Viper/viper.zs
@@ -174,7 +174,7 @@ class HDViper : HDHandgun
 		int cx, cy, cw, ch;
 		[cx, cy, cw, ch] = Screen.GetClipRect();
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 13, sb.DI_SCREEN_CENTER);
-		vector2 bob2 = bob * 2;
+		vector2 bob2 = bob * 1.3;
 		bob2.y = clamp(bob2.y, -8, 8);
 		sb.DrawImage("VIPRFRNT", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9, scale: (0.8, 0.6));
 		sb.SetClipRect(cx, cy, cw, ch);

--- a/zscript/accensus/weapons/Wyvern/wyvern.zs
+++ b/zscript/accensus/weapons/Wyvern/wyvern.zs
@@ -82,14 +82,14 @@ class HDWyvern : HDWeapon {
 
 		[cx, cy, cw, ch] = Screen.GetClipRect();
 		sb.SetClipRect(
-			-16 + bob.x, -4 + bob.y, 32, 12,
+			-16 + bob.x, -32 + bob.y, 32, 38,
 			sb.DI_SCREEN_CENTER
 		);
-		vector2 bob2 = bob * 3;
-		bob2.y = clamp(bob2.y, -8, 8);
+		vector2 bob2 = bob * 1.1;
+		//bob2.y = clamp(bob2.y, -8, 8);
 		sb.DrawImage(
-			"FRNTSITE", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP,
-			scale: (0.7, 1.0)
+			"DBFRNTSIT", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP,
+			scale:(0.7,1.0)
 		);
 		sb.SetClipRect(cx, cy, cw, ch);
 		sb.DrawImage(


### PR DESCRIPTION
Updated the sight bob values to match stock HD. Also fixed a few problems with the scopes on the Redline and Gungnir, mainly redundant DrawImage calls that were just drawing over the DrawCircle call that was already providing the scope.