### PR TITLE
Some Blackjack fixes, Gungnir scope fix

### DIFF
--- a/zscript/accensus/weapons/Blackjack/blackjack.zs
+++ b/zscript/accensus/weapons/Blackjack/blackjack.zs
@@ -299,7 +299,7 @@ class HDBlackjack : HDWeapon
 			{
 				if (invoker.WeaponStatus[BJProp_ChamberPrimary] == 1)
 				{
-					A_EjectCasing("HDSpent355",frandom(-1,2),(6,-frandom(79, 81),frandom(6.0, 6.5)),(0,0,-2));
+					A_EjectCasing("HDSpent355",frandom(-1,2),(frandom(0.2,0.3),-frandom(7,7.5),frandom(0,0.2)),(0,0,-2));
 					//A_EjectCasing('HDSpent355', 6, -random(79, 81), frandom(6.0, 6.5));
 					invoker.WeaponStatus[BJProp_ChamberPrimary] = 0;
 				}
@@ -345,7 +345,7 @@ class HDBlackjack : HDWeapon
 			{
 				if (invoker.WeaponStatus[BJProp_ChamberSecondary] == 1)
 				{
-					A_EjectCasing("HDSpentShell",frandom(-1,2),(11,-frandom(79, 81),frandom(6.0, 6.5)),(0,0,-2));
+					A_EjectCasing("HDSpentShell",frandom(-1,2),(frandom(0.2,0.3),-frandom(7,7.5),frandom(0,0.2)),(0,0,-2));
 					//A_EjectCasing('HDSpentShell', 11, -random(79, 81), frandom(6.0, 6.5));
 					invoker.WeaponStatus[BJProp_ChamberSecondary] = 0;
 				}

--- a/zscript/accensus/weapons/Blackjack/blackjack.zs
+++ b/zscript/accensus/weapons/Blackjack/blackjack.zs
@@ -293,7 +293,7 @@ class HDBlackjack : HDWeapon
 				A_StartSound("Blackjack/Fire", CHAN_WEAPON);
 				A_ZoomRecoil(0.995);
 				A_MuzzleClimb(-frandom(0.3, 0.35), -frandom(0.40, 0.5), -frandom(0.3, 0.35), -frandom(0.40, 0.5));
-				A_Light1();
+				A_GunFlash("Flash");
 			}
 			BJKG A 2 Offset(0, 36)
 			{
@@ -339,7 +339,7 @@ class HDBlackjack : HDWeapon
 				A_StartSound("Blackjack/AltFire", CHAN_WEAPON);
 				A_ZoomRecoil(0.995);
 				A_MuzzleClimb(-frandom(1, 1.2), -frandom(1.5, 2.0), -frandom(1, 1.2), -frandom(1.5, 2.0));
-				A_Light1();
+				A_GunFlash("Flash");
 			}
 			BJKG A 1 Offset(0, 39)
 			{
@@ -365,6 +365,9 @@ class HDBlackjack : HDWeapon
 			BJKG A 1;
 			BJKG A 0 A_Refire();
 			Goto Ready;
+		Flash:
+			TNT1 A 1 A_Light1();
+			goto lightdone;
 
 		Unload:
 			BJKG A 0

--- a/zscript/accensus/weapons/Gungnir/gungnir.zs
+++ b/zscript/accensus/weapons/Gungnir/gungnir.zs
@@ -365,7 +365,7 @@ class HDGungnir : HDCellWeapon
 
 			texman.setcameratotexture(hpc, "HDXCAM_BOSS", 5);
 			let cam  = texman.CheckForTexture("HDXCAM_BOSS",TexMan.Type_Any);
-			sb.DrawCircle(cam,(0,scaledyoffset)+bob*3,.11,usePixelRatio:true);
+			sb.DrawCircle(cam,(0,scaledyoffset)+bob*3,.125,usePixelRatio:true);
 
 			sb.DrawImage("SCOPHOLE", (0, ScaledYOffset) + bob * 5, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, scale: (1.5, 1.5));
 			Screen.SetClipRect(cx, cy, cw, ch);


### PR DESCRIPTION
Since the Blackjack wasn't calling A_GunFlash, it wouldn't break blursphere cloak on altfire. I also fixed the casings being ejected at absurd speeds. Threw in the Gungnir DrawCircle fix while I was at it.