### PR TITLE
Remove vertical clamps on front post bobbing

### DIFF
--- a/zscript/accensus/weapons/Blackjack/blackjack.zs
+++ b/zscript/accensus/weapons/Blackjack/blackjack.zs
@@ -158,7 +158,7 @@ class HDBlackjack : HDWeapon
 		[cx, cy, cw, ch] = Screen.GetClipRect();
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 12, sb.DI_SCREEN_CENTER);
 		vector2 bob2 = bob * 1.14;
-		bob2.y = clamp(bob2.y, -8, 8);
+		//bob2.y = clamp(bob2.y, -8, 8);
 		sb.DrawImage("BJCKFRNT", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9, scale: (0.8, 0.6));
 		sb.SetClipRect(cx, cy, cw, ch);
 		sb.DrawImage("BJCKBACK", bob, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, scale: (1.0, 0.8));
@@ -568,7 +568,7 @@ class HDBlackjack : HDWeapon
 
 				if (invoker.WeaponStatus[chamberIndex] == 1)
 				{
-					A_EjectCasing(casingCls,frandom(-1,2),(6,-frandom(79, 81),frandom(6.0, 6.5)),(0,0,-2));
+					A_EjectCasing(casingCls,frandom(-1,2),(frandom(0.2,0.3),-frandom(7,7.5),frandom(0,0.2)),(0,0,-2));
 					//A_EjectCasing(casingCls, 6, -random(79, 81), frandom(6.0, 6.5));
 				}
 				

--- a/zscript/accensus/weapons/Gungnir/gungnir.zs
+++ b/zscript/accensus/weapons/Gungnir/gungnir.zs
@@ -349,7 +349,7 @@ class HDGungnir : HDCellWeapon
 		[cx, cy, cw, ch] = Screen.GetClipRect();
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 16, sb.DI_SCREEN_CENTER);
 		vector2 bobb = bob * 1.14;
-		bobb.y = clamp(bobb.y, -8, 8);
+		//bobb.y = clamp(bobb.y, -8, 8);
 		sb.DrawImage("GNGRFRNT", bobb, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9);
 		sb.SetClipRect(cx, cy, cw, ch);
 		sb.DrawImage("GNGRBACK", (0, 3) + bob, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER);

--- a/zscript/accensus/weapons/Jackdaw/jackdaw.zs
+++ b/zscript/accensus/weapons/Jackdaw/jackdaw.zs
@@ -58,7 +58,7 @@ class HDJackdaw : HDWeapon
 		[cx, cy, cw, ch] = Screen.GetClipRect();
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 16, sb.DI_SCREEN_CENTER);
 		vector2 bob2 = bob * 1.14;
-		bob2.y = clamp(bob2.y, -8, 8);
+		//bob2.y = clamp(bob2.y, -8, 8);
 		sb.DrawImage("JDWFRONT", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9);
 		sb.SetClipRect(cx, cy, cw, ch);
 		sb.DrawImage("JDWBACK", (0, -7) + bob, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP);

--- a/zscript/accensus/weapons/Majestic/majestic.zs
+++ b/zscript/accensus/weapons/Majestic/majestic.zs
@@ -179,7 +179,7 @@ class HDMajestic : HDHandgun
 		[cx, cy, cw, ch] = Screen.GetClipRect();
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 13, sb.DI_SCREEN_CENTER);
 		vector2 bob2 = bob * 1.14;
-		bob2.y = clamp(bob2.y, -8, 8);
+		//bob2.y = clamp(bob2.y, -8, 8);
 		sb.DrawImage("MJTCFRNT", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9, scale: (0.8, 0.6));
 		sb.SetClipRect(cx, cy, cw, ch);
 		sb.DrawImage("MJTCBACK", bob, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, scale: (0.6, 0.7));

--- a/zscript/accensus/weapons/Redline/redline.zs
+++ b/zscript/accensus/weapons/Redline/redline.zs
@@ -126,7 +126,7 @@ class HDRedline : HDCellWeapon
 	{
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 16, sb.DI_SCREEN_CENTER);
 		vector2 bob2 = bob * 1.14;
-		bob2.y = clamp(bob2.y, -8, 8);
+		//bob2.y = clamp(bob2.y, -8, 8);
 		sb.DrawImage("REDFRONT", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9);
 		sb.ClearClipRect();
 		sb.DrawImage("REDBACK", bob, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP);

--- a/zscript/accensus/weapons/Viper/viper.zs
+++ b/zscript/accensus/weapons/Viper/viper.zs
@@ -175,7 +175,7 @@ class HDViper : HDHandgun
 		[cx, cy, cw, ch] = Screen.GetClipRect();
 		sb.SetClipRect(-16 + bob.x, -4 + bob.y, 32, 13, sb.DI_SCREEN_CENTER);
 		vector2 bob2 = bob * 1.3;
-		bob2.y = clamp(bob2.y, -8, 8);
+		//bob2.y = clamp(bob2.y, -8, 8);
 		sb.DrawImage("VIPRFRNT", bob2, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, alpha: 0.9, scale: (0.8, 0.6));
 		sb.SetClipRect(cx, cy, cw, ch);
 		sb.DrawImage("VIPRBACK", bob, sb.DI_SCREEN_CENTER | sb.DI_ITEM_TOP, scale: (0.9, 0.7));


### PR DESCRIPTION
Another exciting episode of finding something that was removed from stock HD weapons years ago and all the modders missed it. This fixes the front sights getting cut off during bobbing and not following the back sights in a way that makes any sense.

I also caught one last Blackjack casing ejection that I'd missed before.