### PR TITLE
Update DSD Logic to better match current Backpack structure

### DIFF
--- a/LANGUAGE
+++ b/LANGUAGE
@@ -323,3 +323,17 @@ PICKUP_SUPPLYBEACON                     = "Picked up a supply drop beacon.";
 PICKUP_TELEPORTER                       = "Picked up a portable teleporter.";
 
 SUPERSTIM_HELPTEXT                      = "\cd<<< \cjSUPER STIMPACK \cd>>>\c-\n\n\nSuper stimpacks give a rapid\nbut short boost to\nhealth regeneration.\n\n\Press altfire to use on someone else.\n\n\cgDO NOT OVERDOSE.";
+
+DSD_TOP                                 = "\c[DarkBrown][] [] [] \c[Cyan]Dimensional Storage Device \c[DarkBrown][] [] []";
+DSD_INOPERABLE                          = "!!! INOPERABLE !!!";
+DSD_OPERATIONSLEFT                      = "\c[Brown]Operations left: \c-";
+DSD_TOOFULL                             = "Your storage is full.";
+DSD_INBAG                               = "In Device:  ";
+DSD_INSERTREMOVE                        = "Insert/Remove:  ";
+DSD_SEARCHING                           = "Searching:  ";
+
+DSDWH_FMODPUD                           = "  Adjust operation amount\n";
+DSDWH_ENTER                             = "  Search mode/apply search\n";
+DSDWH_USEALTRELOAD                      = "  Sort descending/ascending\n";
+DSDWH_USERELOAD                         = "  Load battery\n";
+DSDWH_USEUNLOAD                         = "  Remove battery";

--- a/zscript.zs
+++ b/zscript.zs
@@ -19,6 +19,8 @@ const HDLD_VIPER              = "vpr";
 const HDLD_VIPERMAG           = "vpm";
 const HDLD_WYVERN             = "wyv";
 
+const HDLD_DSD                = "dsd";
+
 // Core
 #include "zscript/accensus/SpawnHandler.zs"
 

--- a/zscript/accensus/items/Dimensional Storage Device.zs
+++ b/zscript/accensus/items/Dimensional Storage Device.zs
@@ -94,6 +94,9 @@ class DSDHandler : EventHandler
 
 class DSDStorage : ItemStorage
 {
+	string SearchString;
+	bool InSearchMode;
+
 	void ApplySearch()
 	{
 		if (SearchString == "")
@@ -133,122 +136,112 @@ class DSDStorage : ItemStorage
 		InSearchMode = false;
 	}
 
-	override string GetFailMessage()
-	{
-		return "Your storage is full.";
-	}
-
-	override int GetOperationSpeed(class<Inventory> item, int operation)
-	{
-		let wpn = (class<HDWeapon>)(item);
-		let pkp = (class<HDPickup>)(item);
-		bool multipickup = pkp && GetDefaultByType(pkp).bMULTIPICKUP;
-		switch (operation)
-		{
-			case SIIAct_Extract: return wpn ? 20 : multipickup ? 6 : 6;
-			case SIIAct_Insert: return wpn ? 20 : multipickup ? 6 : 6;
-		}
-		return 20;
-	}
-
-	override int CheckConditions(Inventory item, class<Inventory> cls)
-	{
+	override int CheckConditions(
+		Inventory item,
+		class<Inventory> cls
+	){
 		if (item)
 		{
 			let wpn = HDWeapon(item);
-			let arm = HDArmour(item);
 			let mag = HDMagAmmo(item);
 			let pkp = HDPickup(item);
 
-			if (item is 'HDBackpack')
-			{
-				return IType_Invalid;
-			}
-			if (wpn && !wpn.bNOINTERACTION && !wpn.bUNDROPPABLE && !wpn.bUNTOSSABLE && !wpn.bCHEATNOTWEAPON)
-			{
-				return IType_Weapon;
-			}
-			/*
-			if (arm)
-			{
-				return IType_Armour;
-			}
-			*/
-			if (mag)
-			{
-				return IType_Mag;
-			}
-			if (pkp && !pkp.bNOINTERACTION && !pkp.bUNDROPPABLE && !pkp.bUNTOSSABLE && pkp.bFITSINBACKPACK)
-			{
-				return IType_Pickup;
-			}
+			if(
+				item.bNOINTERACTION
+				||item.bUNDROPPABLE
+				||item.bUNTOSSABLE
+				||(
+					//container that is in use
+					item is 'HDBackpack'
+					&&HDBackpack(item).Storage
+					&&HDBackpack(item).Storage.TotalBulk>0
+				)||(
+					//pickup that does not fit in backpack
+					pkp
+					&&!pkp.bFITSINBACKPACK
+				)
+			)return IType_Invalid;
+
+			//some exceptions only apply to weapons
+			if(
+				wpn
+				// &&!wpn.bINVBAR
+				&&!wpn.bCHEATNOTWEAPON
+			)return IType_Weapon;
+
+			if(mag)return IType_Mag;
+			if(pkp)return IType_Pickup;
 		}
 		else if (cls)
 		{
+			let dls=GetDefaultByType((class<Inventory>)(cls));
 			let wpn = cls is 'HDWeapon' ? GetDefaultByType((class<HDWeapon>)(cls)) : null;
-			//let arm = cls is 'HDArmour' ? GetDefaultByType((class<HDArmour>)(cls)) : null;
 			let mag = cls is 'HDMagAmmo' ? GetDefaultByType((class<HDMagAmmo>)(cls)) : null;
 			let pkp = cls is 'HDPickup' ? GetDefaultByType((class<HDPickup>)(cls)) : null;
 
-			if (wpn && !wpn.bNOINTERACTION && !wpn.bUNDROPPABLE && !wpn.bUNTOSSABLE && !wpn.bCHEATNOTWEAPON && wpn.GetTag() != wpn.GetClassName())
-			{
-				return IType_Weapon;
-			}
-			/*
-			if (arm && arm.GetTag() != arm.GetClassName())
-			{
-				return IType_Armour;
-			}
-			*/
-			if (mag && mag.GetTag() != mag.GetClassName())
-			{
-				return IType_Mag;
-			}
-			if (pkp && !pkp.bNOINTERACTION && !pkp.bUNDROPPABLE && !pkp.bUNTOSSABLE && pkp.bFITSINBACKPACK && pkp.GetTag() != pkp.GetClassName())
-			{
-				return IType_Pickup;
-			}
+			if(
+				dls.bNOINTERACTION
+				||dls.bUNDROPPABLE
+				||dls.bUNTOSSABLE
+				||dls.GetTag()==dls.GetClassName()
+				||(
+					pkp
+					&&!pkp.bFITSINBACKPACK
+				)
+			)return IType_Invalid;
+
+			if(
+				wpn
+				&&!wpn.bCHEATNOTWEAPON
+				// &&!wpn.bINVBAR
+			)return IType_Weapon;
+
+			if(mag)return IType_Mag;
+			if(pkp)return IType_Pickup;
 		}
 
 		return IType_Invalid;
 	}
 
-	/*
-	override int TryInsertItem(Inventory item, Actor inserter, int amt, int index, bool noInsert, int flags)
-	{
-		if (flags & bFITSINBACKPACK)
-		//if (flags & BF_FROMMANAGER)
-		{
-			return 0;
+	override int GetOperationSpeed(
+		class<Inventory> item,
+		int operation
+	){
+		let wpn = (class<HDWeapon>)(item);
+		let pkp = (class<HDPickup>)(item);
+		bool multipickup=pkp && GetDefaultByType(pkp).bMULTIPICKUP;
+		switch (operation){
+			case SIIAct_Extract:return wpn ? 20 : multipickup ? 6 : 6;
+			case SIIAct_Insert:return wpn ? 20 : multipickup ? 6 : 6;
+			default:break;
 		}
-		
-		return Super.TryInsertItem(item, inserter, amt, index, noInsert, flags);
+		return 20;
 	}
-	*/
+
+	override string GetFailMessage() const
+	{
+		return Stringtable.Localize("$DSD_TOOFULL");
+	}
+
 	override Inventory RemoveItem(StorageItem item, Actor remover, Actor receiver, int amt, int index, int flags)
 	{
 		if (!item || item.Amounts.Size() == 0 || amt < 1)
-		//if (!item || item.Amounts.Size() == 0 || amt < 1 || flags & bFITSINBACKPACK)
 		{
 			return null;
 		}
 
 		let wpn = (class<HDWeapon>)(item.ItemClass);
-		//let arm = (class<HDArmour>)(item.ItemClass);
 		let mag = (class<HDMagAmmo>)(item.ItemClass);
 		let pkp = (class<HDPickup>)(item.ItemClass);
 
-		Inventory spawned = null;
+		Inventory Spawned = null;
 		vector3 SpawnPos = (0, 0, 0);
 		if (remover)
 		{
 			for (int i = 64; i >= 0; i -= 8)
 			{
 				SpawnPos = remover.Vec3Angle(i - 8, remover.angle, remover.height / 2 + 6);
-				if (level.IsPointInLevel(SpawnPos))
-				{
-					break;
-				}
+				if (level.IsPointInLevel(SpawnPos)) break;
 			}
 		}
 		if (wpn)
@@ -263,17 +256,21 @@ class DSDStorage : ItemStorage
 			{
 				if (remover)
 				{
-					spawned = Inventory(Actor.Spawn(wpn, SpawnPos));
-					HDWeapon newwpn = HDWeapon(spawned);
+					Spawned = Inventory(Actor.Spawn(wpn, SpawnPos));
+					HDWeapon newwpn = HDWeapon(Spawned);
+					newwpn.bdontdefaultconfigure=true;
 					for (int i = 0; i < HDWEP_STATUSSLOTS; ++i)
 					{
 						newwpn.WeaponStatus[i] = item.WeaponStatus[HDWEP_STATUSSLOTS * index + i];
+					}
+					if (receiver)
+					{
+						newwpn.ActualPickup(receiver, flags & BF_SILENT);
 					}
 					if (newwpn.bDROPTRANSLATION)
 					{
 						newwpn.Translation = remover.Translation;
 					}
-					newwpn.A_ChangeVelocity(0, 0, frandom(0, 2), CVF_RELATIVE);
 				}
 				item.WeaponStatus.Delete(HDWEP_STATUSSLOTS * index, HDWEP_STATUSSLOTS);
 				if (item.Icons.Size() > 1) // [Ace] Don't delete the last icon. It is used for the preview.
@@ -288,11 +285,10 @@ class DSDStorage : ItemStorage
 				}
 			}
 		}
-		else if (mag)// || arm)
+		else if (mag)
 		{
 			index = min(index, item.Amounts.Size() - 1);
-			amt = min(1, amt, item.Amounts[0]);
-			//amt = min(arm ? 1 : amt, item.Amounts.Size());
+			amt = min(amt, item.Amounts.Size());
 			if (remover && !(flags & BF_FROMCONSOLIDATE))
 			{
 				Actor.Spawn("DSDSpawnEffect", SpawnPos);
@@ -301,12 +297,13 @@ class DSDStorage : ItemStorage
 			{
 				if (remover)
 				{
-					spawned = Inventory(Actor.Spawn(mag, SpawnPos));
-					//spawned = Inventory(Actor.Spawn(arm ? (class<HDMagAmmo>)(arm) : mag, SpawnPos));
-					HDMagAmmo newmag = HDMagAmmo(spawned);
-					newmag.Mags[0] = item.Amounts[index];
-					newmag.angle = random(0, 359);
-					newmag.A_ChangeVelocity(frandom(-0.1, 0.4), 0, frandom(0, 3), CVF_RELATIVE);
+					Spawned = Inventory(Actor.Spawn(mag, SpawnPos));
+					HDMagAmmo newmag = HDMagAmmo(Spawned);
+					newmag.Mags[0]=item.Amounts[0];
+					if (receiver)
+					{
+						newmag.ActualPickup(receiver, true);
+					}
 				}
 				if (item.Icons.Size() > 1)
 				{
@@ -325,11 +322,13 @@ class DSDStorage : ItemStorage
 				{
 					Actor.Spawn("DSDSpawnEffect", SpawnPos);
 				}
-				spawned = Inventory(Actor.Spawn(pkp, SpawnPos));
-				HDPickup newpkp = HDPickup(spawned);
+				Spawned = Inventory(Actor.Spawn(pkp, SpawnPos));
+				HDPickup newpkp = HDPickup(Spawned);
 				newpkp.Amount = amt;
-				newpkp.angle = random(0, 359);
-				newpkp.A_ChangeVelocity(frandom(-0.1, 0.4), 0, frandom(0, 3), CVF_RELATIVE);
+				if (receiver)
+				{
+					newpkp.ActualPickup(receiver, true);
+				}
 			}
 			item.Bulks[0] -= amt * GetDefaultByType(pkp).Bulk;
 			item.Amounts[0] -= amt;
@@ -338,14 +337,16 @@ class DSDStorage : ItemStorage
 				item.Amounts.Delete(0);
 			}
 		}
+		if(Spawned){
+			Spawned.angle = remover.angle;
+			Spawned.A_ChangeVelocity(1.5*cos(remover.pitch),0,1.-1.5*sin(remover.pitch),CVF_RELATIVE);
+			Spawned.vel += remover.vel;
+		}
 
 		RemoveNullOrEmpty(remover);
 		CalculateBulk();
-		return spawned;
+		return Spawned;
 	}
-
-	string SearchString;
-	bool InSearchMode;
 }
 
 class DSDStorageThinker : Thinker
@@ -419,76 +420,75 @@ class DSDInterface : HDBackpack
 		Super.Tick();
 	}
 
-	override void UpdateCapacity() {}
-	override void DropOneAmmo(int amt) {}
-	override void Consolidate() {}
-	override void LoadoutConfigure(string input)
-	{
+	override void UpdateCapacity(){
+		// no-op
+	}
+
+	override bool IsBeingWorn() { return false; }
+	override string, double GetPickupSprite() { return "DSDDA0", 1.0; }
+	override double WeaponBulk() { return 60; }
+	override string GetHelpText(){
+		LocalizeHelp();
+		return LWPHELP_FIRE.."/"..LWPHELP_ALTFIRE..StringTable.Localize("$BPWH_PNI")
+		..LWPHELP_FIREMODE.."+"..LWPHELP_UPDOWN..StringTable.Localize("$DSDWH_FMODPUD")
+		..LWPHELP_RELOAD..StringTable.Localize("$BPWH_RELOAD")
+		..LWPHELP_UNLOAD..StringTable.Localize("$BPWH_UNLOAD")
+		..WEPHELP_BTCOL.."Enter"..WEPHELP_RGCOL..StringTable.Localize("$DSDWH_ENTER")
+		..LWPHELP_ALTRELOAD.."(+"..LWPHELP_USE..")"..StringTable.Localize("$DSDWH_USEALTRELOAD")
+		..LWPHELP_USE.."(hold) + "..LWPHELP_RELOAD..StringTable.Localize("$DSDWH_USERELOAD")
+		..LWPHELP_USE.."(hold) + "..LWPHELP_UNLOAD..StringTable.Localize("$DSDWH_USEUNLOAD");
+	}
+
+	//configure from loadout
+	override void LoadoutConfigure(string input){
 		ConfigString = input;
 		StartingCapacity = GetLoadoutVar(input, "cap", 5);
 	}
-	override bool CanGrabInsert(Inventory item, class<Inventory> item, Actor grabber) { return false; }
-	override bool IsBeingWorn() { return false; }
-	override string, double GetPickupSprite(){ return "DSDDA0", 1.0; }
-	override double WeaponBulk() { return 60; }
 
-	override void InitializeWepStats(bool idfa)
+	override void DropOneAmmo(int amt)
 	{
-		WeaponStatus[DSDProp_Battery] = -1;
+		// no-op
 	}
 
-	override string GetHelpText()
-	{
-		return WEPHELP_FIRE.."/"..WEPHELP_ALTFIRE.."  Previous/Next item\n"
-		..WEPHELP_FIREMODE.."+"..WEPHELP_UPDOWN.."  Adjust operation amount\n"
-		..WEPHELP_RELOAD.."  Insert\n"
-		..WEPHELP_UNLOAD.."  Remove\n"
-		..WEPHELP_BTCOL.."Enter"..WEPHELP_RGCOL.."  Search mode/apply search\n"
-		..WEPHELP_ALTRELOAD.."(+"..WEPHELP_USE..")  Sort descending/ascending\n"
-		..WEPHELP_USE.."(hold) + "..WEPHELP_RELOAD.."  Load battery\n"
-		..WEPHELP_USE.."(hold) + "..WEPHELP_UNLOAD.."  Remove battery";
-	}
+	override bool CanGrabInsert(Inventory item, class<Inventory> item, Actor grabber) {return false;}
 
-	override void DrawHUDStuff(HDStatusBar sb, HDWeapon hdw, HDPlayerPawn hpl)
-	{
-		int yOff = -80;
+	override void Consolidate(){Storage.Consolidate(owner);}
+
+	override void DrawHUDStuff(HDStatusBar sb, HDWeapon hdw, HDPlayerPawn hpl){
+		int BaseOffset = -80;
 
 		if (WeaponStatus[DSDProp_Battery] > -1)
 		{
-			sb.DrawImage(AceCore.GetBatteryColor(WeaponStatus[DSDProp_Battery]), (0, yOff - 5), sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER_BOTTOM, box: (-1, 20), scale: (2.0, 2.0));
+			sb.DrawImage(AceCore.GetBatteryColor(WeaponStatus[DSDProp_Battery]), (0, BaseOffset - 5), sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER_BOTTOM, box: (-1, 20), scale: (2.0, 2.0));
 		}
 
-		sb.DrawString(sb.pSmallFont, "\c[DarkBrown][] [] [] \c[Cyan]Dimensional Storage Device \c[DarkBrown][] [] []", (0, yOff), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER);
-		sb.DrawString(sb.pSmallFont, String.Format("Total Bulk: \cf%.2f/%i\c-", Storage.TotalBulk, Storage.MaxBulk), (0, yOff + 10), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER);
+		sb.DrawString(sb.pSmallFont, StringTable.Localize("$DSD_TOP"), (0, BaseOffset), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER);
+		sb.DrawString(sb.pSmallFont, Stringtable.Localize("$BACKPACK_TOTALBULK")..int(Storage.TotalBulk).."/"..int(Storage.MaxBulk).."\c-", (0, BaseOffset + 10), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER);
 		if (WeaponStatus[DSDProp_Battery] <= 0)
 		{
 			if (level.time % 50 < 25)
 			{
-				sb.DrawString(sb.pSmallFont, "!!! INOPERABLE !!!", (0, yOff + 20), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_RED);
+				sb.DrawString(sb.pSmallFont, StringTable.Localize("$DSD_INOPERABLE"), (0, BaseOffset + 20), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_RED);
 			}
 		}
 		else
 		{
-			sb.DrawString(sb.pSmallFont, "\c[Brown]Operations left: \c-"..(WeaponStatus[DSDProp_Battery]), (0, yOff + 20), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_GREEN);
+			sb.DrawString(sb.pSmallFont, StringTable.Localize("$DSD_OPERATIONSLEFT")..(WeaponStatus[DSDProp_Battery]), (0, BaseOffset + 20), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_GREEN);
 		}
 
-		yOff += 40;
+		BaseOffset += 40;
 
-		int itemCount = Storage.Items.Size();
-		if (itemCount == 0)
-		{
-			sb.DrawString(sb.pSmallFont, "No items found.", (0, yOff), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_DARKGRAY);
+		int ItemCount = Storage.Items.Size();
+
+		if(!ItemCount){
+			sb.DrawString(sb.pSmallFont, Stringtable.Localize("$BACKPACK_NOITEMS"), (0, BaseOffset), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_DARKGRAY);
 			return;
 		}
 		
-		StorageItem selItem = Storage.GetSelectedItem();
-		if (!selItem)
-		{
-			return;
-		}
+		StorageItem SelItem = Storage.GetSelectedItem();
+		if(!SelItem)return;
 
-		for (int i = 0; i < (ItemCount > 1 ? 5 : 1); ++i)
-		{
+		for(int i = 0; i < (ItemCount > 1 ? 5 : 1); ++i){
 			int RealIndex = (Storage.SelItemIndex + (i - 2)) % ItemCount;
 			if (RealIndex < 0)
 			{
@@ -506,62 +506,63 @@ class DSDInterface : HDBackpack
 
 			StorageItem CurItem = Storage.Items[RealIndex];
 			bool CenterItem = Offset ~== (0, 0);
-			sb.DrawImage(CurItem.Icons[0], (Offset.x, yOff + 10 + Offset.y), sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, CenterItem && !CurItem.HaveNone() ? 1.0 : 0.6, CenterItem ? (50, 30) : (30, 20), GetDefaultByType(CurItem.ItemClass).Scale * (CenterItem ? 4.0 : 3.0));
+			sb.DrawImage(CurItem.Icons[0], (Offset.x, BaseOffset + 10 + Offset.y), sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, CenterItem && !CurItem.HaveNone() ? 1.0 : 0.6, CenterItem ? (50, 30) : (30, 20), getdefaultbytype(CurItem.ItemClass).scale*(CenterItem?4.0:3.0));
 		}
 		
-		sb.DrawString(sb.pSmallFont, selItem.NiceName, (0, yOff + 30), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_FIRE);
+		sb.DrawString(sb.pSmallFont, SelItem.NiceName, (0, BaseOffset + 30), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_FIRE);
 
-		int AmountInBackpack = selItem.ItemClass is 'HDMagAmmo' ? selItem.Amounts.Size() : (selItem.Amounts.Size() > 0 ? selItem.Amounts[0] : 0);
-		sb.DrawString(sb.pSmallFont, "In backpack:  "..sb.FormatNumber(AmountInBackpack, 1, 6), (0, yOff + 40), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, AmountInBackpack > 0 ? Font.CR_BROWN : Font.CR_DARKBROWN);
+		int AmountInBackpack = SelItem.ItemClass is 'HDMagAmmo' ? SelItem.Amounts.Size() : (SelItem.Amounts.Size() > 0 ? SelItem.Amounts[0] : 0);
+		sb.DrawString(sb.pSmallFont, StringTable.Localize("$DSD_INBAG")..sb.FormatNumber(AmountInBackpack, 1, 6), (0, BaseOffset + 40), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, AmountInBackpack > 0 ? Font.CR_BROWN : Font.CR_DARKBROWN);
 
-		int AmountOnPerson = GetAmountOnPerson(hpl.FindInventory(selItem.ItemClass));
-		sb.DrawString(sb.pSmallFont, "On person:  "..sb.FormatNumber(AmountOnPerson, 1, 6), (0, yOff + 48), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, AmountOnPerson > 0 ?  Font.CR_WHITE : Font.CR_DARKGRAY);
+		int AmountOnPerson = GetAmountOnPerson(hpl.FindInventory(SelItem.ItemClass));
+		sb.DrawString(sb.pSmallFont, StringTable.Localize("$BACKPACK_ONPERSON")..sb.FormatNumber(AmountOnPerson, 1, 6), (0, BaseOffset + 48), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, AmountOnPerson > 0 ?  Font.CR_WHITE : Font.CR_DARKGRAY);
 
-		if (selItem.ItemClass is 'HDPickup' && !(selItem.ItemClass is 'HDArmour'))
+		if ((SelItem.ItemClass is 'HDPickup') && !(SelItem.ItemClass is 'HDArmour'))
 		{
-			sb.DrawString(sb.pSmallFont, "Insert/remove:  "..sb.FormatNumber(OperationAmount, 1, 3), (0, yOff + 56), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_SAPPHIRE);
+			sb.DrawString(sb.pSmallFont, StringTable.Localize("$DSD_INSERTREMOVE")..sb.FormatNumber(OperationAmount, 1, 3), (0, BaseOffset + 56), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_SAPPHIRE);
 		}
 
 		if (DSDStorage(Storage).InSearchMode)
 		{
-			sb.DrawString(sb.pSmallFont, "Searching: "..DSDStorage(Storage).SearchString.."_", (-60, yOff + 64), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT, Font.CR_WHITE);
+			sb.DrawString(sb.pSmallFont, StringTable.Localize("$DSD_SEARCHING")..DSDStorage(Storage).SearchString.."_", (-60, BaseOffset + 64), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT, Font.CR_WHITE);
 		}
 
-		if (selItem.ItemClass is 'HDArmour')
+		if (SelItem.ItemClass is 'HDArmour')
 		{
-			for (int i = 0; i < selItem.Amounts.Size(); ++i)
+			for (int i = 0; i < SelItem.Amounts.Size(); ++i)
 			{
-				vector2 Off = (-126 + 35 * (i % 8), yOff + 90 + 35 * (i / 8));
-				sb.DrawImage(selItem.Icons[i], Off, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, 1.0, (30, 20), (4.0, 4.0));
-				sb.DrawString(sb.mAmountFont, sb.FormatNumber(selItem.Amounts[i] > 1000 ? selItem.Amounts[i] - 1000 : selItem.Amounts[i], 1, 4), Off + (0, 12), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_YELLOW);
+				vector2 Off = (-126 + 35 * (i % 8), BaseOffset + 90 + 35 * (i / 8));
+				sb.DrawImage(SelItem.Icons[i], Off, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, 1.0, (30, 20), (4.0, 4.0));
+				sb.DrawString(sb.mAmountFont, sb.FormatNumber(SelItem.Amounts[i] > 1000 ? SelItem.Amounts[i] - 1000 : SelItem.Amounts[i], 1, 4), Off + (0, 12), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_CENTER, Font.CR_YELLOW);
 			}
 		}
-		else if (selItem.ItemClass is 'HDMagAmmo' && GetDefaultByType((class<HDMagAmmo>)(selItem.ItemClass)).MaxPerUnit)
+		else if (SelItem.ItemClass is 'HDMagAmmo' && GetDefaultByType((class<HDMagAmmo>)(SelItem.ItemClass)).MaxPerUnit)
 		{
-			int size = selItem.Amounts.Size();
-			for (int i = 0; i < size; ++i)
+			for (int i = 0; i < SelItem.Amounts.Size(); ++i)
 			{
-				vector2 off = (-160 + 42 * (i / 10) - 2 * i, yOff + 90 + 12 * (i % 10));
-				sb.DrawImage(selItem.Icons[i], off, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, OperationAmount > i ? 1.0 : 0.5, (10, 20), (4.0, 4.0));
-			}
-			for (int i = 0; i < size; ++i)
-			{
-				int magAmt = selItem.Amounts[i];
-				if (magAmt == 51 && selItem.ItemClass is 'HD4mMag')
-				{
-					magAmt = 50;
-				}
-				vector2 off = (-160 + 42 * (i / 10) - 2 * i, yOff + 90 + 12 * (i % 10));
-				sb.DrawString(sb.mAmountFont, sb.FormatNumber(magAmt, 1, 4), off + (5, 3), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT, Font.CR_YELLOW, OperationAmount > i ? 1.0 : 0.5);
+				vector2 Off = (-160 + 42 * (i / 10) - 2 * i, BaseOffset + 90 + 12 * (i % 10));
+				sb.DrawImage(SelItem.Icons[i], Off, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, OperationAmount > i ? 1.0 : 0.5, (10, 20), (4.0, 4.0));
+				int magAmt = SelItem.Amounts[i];
+				if (magAmt == 51 && SelItem.ItemClass is 'HD4mMag') magAmt = 50;
+
+				// Account for Magazines that leverage the "recast" mechanic by only considering the "total rounds" portion of the magAmt.
+				name libMagName = 'HD7mMag';
+				class<HDMagAmmo> libMag = (class<HDMagAmmo>)(libMagName);
+				name cawsMagName = 'HD_CAWSMag';
+				class<HDMagAmmo> cawsMag = (class<HDMagAmmo>)(cawsMagName);
+				if (SelItem.ItemClass is libMag || SelItem.ItemClass is cawsMag) magAmt %= 100;
+
+				Off = (-160 + 42 * (i / 10) - 2 * i, BaseOffset + 90 + 12 * (i % 10));
+				sb.DrawString(sb.mAmountFont, sb.FormatNumber(magAmt, 1, 4), Off + (5, 3), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT, Font.CR_YELLOW, OperationAmount > i ? 1.0 : 0.5);
 			}
 		}
-		else if (selItem.ItemClass is 'HDWeapon' && selItem.Amounts.Size() > 0 && selItem.Amounts[0] > 1)
+		else if (SelItem.ItemClass is 'HDWeapon' && SelItem.Amounts.Size() > 0 && SelItem.Amounts[0] > 1)
 		{
 			// [Ace] Don't display the first weapon. It's already in the preview.
-			for (int i = 1; i < selItem.Amounts[0]; ++i)
+			for (int i = 1; i < SelItem.Amounts[0]; ++i)
 			{
-				vector2 Off = (-120 + 60 * ((i - 1) % 5), yOff + 90 + 30 * ((i - 1) / 5));
-				sb.DrawImage(selItem.Icons[i], Off, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, 1.0, (50, 20), (4.0, 4.0));
+				vector2 Off = (-120 + 60 * ((i - 1) % 5), BaseOffset + 90 + 30 * ((i - 1) / 5));
+				sb.DrawImage(SelItem.Icons[i], Off, sb.DI_SCREEN_CENTER | sb.DI_ITEM_CENTER, 1.0, (50, 20), (4.0, 4.0));
 			}
 		}
 	}
@@ -584,22 +585,110 @@ class DSDInterface : HDBackpack
 		Super.ActualPickup(other, silent);
 	}
 
+	protected action void A_DSDReady()
+	{
+		if (pressinguse())invoker.A_SetHelpText();
+
+		if (PressingFiremode())
+		{
+			if (JustPressed(BT_ATTACK)) invoker.OperationAmount++;
+			else if (JustPressed(BT_ALTATTACK)) invoker.OperationAmount--;
+
+			int InputAmount = GetMouseY(true);
+			if (InputAmount != 0) invoker.OperationAmount += int(ceil(InputAmount / 64.0));
+
+			invoker.OperationAmount = clamp(invoker.OperationAmount, 1, 200);
+		}
+		else
+		{
+			invoker.RepeatTics--;
+			A_WeaponReady(WRF_ALLOWUSER3);
+			if (JustPressed(BT_ALTRELOAD)) A_Sort(PressingUse());
+			if (JustPressed(BT_ATTACK))
+			{
+				A_UpdateStorage();
+				invoker.Storage.PrevItem();
+			}
+			else if (JustPressed(BT_ALTATTACK))
+			{
+				A_UpdateStorage();
+				invoker.Storage.NextItem();
+			}
+
+			if (invoker.RepeatTics <= 0)
+			{
+				if (PressingReload())
+				{
+					if (PressingUse())
+					{
+						if (invoker.WeaponStatus[DSDProp_Battery] == -1)
+						{
+							SetWeaponState('InsertBattery');
+						}
+					}
+					else if (invoker.WeaponStatus[DSDProp_Battery] >= 1)
+					{
+						A_UpdateStorage();
+						StorageItem SelItem = invoker.Storage.GetSelectedItem();
+						if (SelItem)
+						{
+							int inserted = invoker.Storage.TryInsertItem(SelItem.InvRef, self, invoker.OperationAmount);
+							invoker.RepeatTics = invoker.Storage.GetOperationSpeed(SelItem.ItemClass, SIIAct_Insert);
+							if (inserted > 0)
+							{
+								invoker.WeaponStatus[DSDProp_Battery] -= 1;
+							}
+						}
+					}
+				}
+				else if (PressingUnload())
+				{
+					if (PressingUse())
+					{
+						if (invoker.WeaponStatus[DSDProp_Battery] > -1)
+						{
+							SetWeaponState('RemoveBattery');
+						}
+					}
+					else if (invoker.WeaponStatus[DSDProp_Battery] >= 1)
+					{
+						A_UpdateStorage();
+						StorageItem SelItem = invoker.Storage.GetSelectedItem();
+						if (SelItem)
+						{
+							Inventory removed = invoker.Storage.RemoveItem(SelItem, self, null, invoker.OperationAmount);
+							invoker.RepeatTics = invoker.Storage.GetOperationSpeed(SelItem.ItemClass, SIIAct_Extract);
+							if (removed)
+							{
+								invoker.WeaponStatus[DSDProp_Battery] -= 1;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	override void InitializeWepStats(bool idfa){
+		WeaponStatus[DSDProp_Battery] = -1;
+	}
+
 	private action void A_Sort(bool ascending)
 	{
 		A_UpdateStorage();
-		StorageItem selItem = invoker.Storage.GetSelectedItem();
-		int size = selItem.Amounts.Size();
+		StorageItem SelItem = invoker.Storage.GetSelectedItem();
+		int size = SelItem.Amounts.Size();
 		if (size > 1) // [Ace] It's a mag.
 		{
 			for (int i = 0; i < size - 1; ++i)
 			{
 				for (int j = i + 1; j < size; ++j)
 				{
-					if (!ascending && selItem.Amounts[i] > selItem.Amounts[j] || ascending && selItem.Amounts[i] < selItem.Amounts[j])
+					if (!ascending && SelItem.Amounts[i] > SelItem.Amounts[j] || ascending && SelItem.Amounts[i] < SelItem.Amounts[j])
 					{
-						let swpAmt = selItem.Amounts[i]; selItem.Amounts[i] = selItem.Amounts[j]; selItem.Amounts[j] = swpAmt; 
-						let swpBulk = selItem.Bulks[i]; selItem.Bulks[i] = selItem.Bulks[j]; selItem.Bulks[j] = swpBulk; 
-						let swpIcon = selItem.Icons[i]; selItem.Icons[i] = selItem.Icons[j]; selItem.Icons[j] = swpIcon; 
+						let swpAmt = SelItem.Amounts[i]; SelItem.Amounts[i] = SelItem.Amounts[j]; SelItem.Amounts[j] = swpAmt; 
+						let swpBulk = SelItem.Bulks[i]; SelItem.Bulks[i] = SelItem.Bulks[j]; SelItem.Bulks[j] = swpBulk; 
+						let swpIcon = SelItem.Icons[i]; SelItem.Icons[i] = SelItem.Icons[j]; SelItem.Icons[j] = swpIcon; 
 					}
 				}
 			}
@@ -610,26 +699,25 @@ class DSDInterface : HDBackpack
 	private string ConfigString;
 	private int StartingCapacity;
 
-	Default
-	{
+	Default{
 		+INVENTORY.INVBAR
 		+WEAPON.WIMPY_WEAPON
 		-HDWEAPON.DROPTRANSLATION
 		-HDWEAPON.FITSINBACKPACK
 		+HDWEAPON.ALWAYSSHOWSTATUS
 		+HDWEAPON.IGNORELOADOUTAMOUNT
-		HDWeapon.WornLayer 0;
 		Weapon.SelectionOrder 1010;
 		Inventory.Icon "DSDDA0";
 		Inventory.PickupMessage "$PICKUP_DSD";
 		Inventory.PickupSound "weapons/pocket";
 		Tag "$TAG_DSD";
-		HDWeapon.RefId "dsd";
+		HDWeapon.RefId HDLD_DSD;
 		Scale 0.5;
 		HDWeapon.loadoutcodes "
 			\cucap - 0-???, Overrides the capacity of the Dimensional Storage Device.
 			\cuNOTE: THIS IS CONSIDERED A CHEAT.
 		";
+		HDWeapon.wornlayer 0;
 	}
 	
 	States
@@ -650,101 +738,7 @@ class DSDInterface : HDBackpack
 			TNT1 A 0 A_Lower(999);
 			Wait;
 		Ready:
-			TNT1 A 1
-			{
-				if (PressingFiremode())
-				{
-					if (JustPressed(BT_ATTACK))
-					{
-						invoker.OperationAmount++;
-					}
-					else if (JustPressed(BT_ALTATTACK))
-					{
-						invoker.OperationAmount--;
-					}
-
-					int InputAmount = GetMouseY(true);
-					if (InputAmount != 0)
-					{
-						invoker.OperationAmount += int(ceil(InputAmount / 64.0));
-					}
-
-					invoker.OperationAmount = clamp(invoker.OperationAmount, 1, 200);
-				}
-				else
-				{
-					invoker.RepeatTics--;
-					A_WeaponReady(WRF_ALLOWUSER3);
-					if (JustPressed(BT_ALTRELOAD))
-					{
-						A_Sort(PressingUse());
-					}
-					if (JustPressed(BT_ATTACK))
-					{
-						A_UpdateStorage();
-						invoker.Storage.PrevItem();
-					}
-					else if (JustPressed(BT_ALTATTACK))
-					{
-						A_UpdateStorage();
-						invoker.Storage.NextItem();
-					}
-
-					if (invoker.RepeatTics <= 0)
-					{
-						if (PressingReload())
-						{
-							if (PressingUse())
-							{
-								if (invoker.WeaponStatus[DSDProp_Battery] == -1)
-								{
-									SetWeaponState('InsertBattery');
-								}
-								return;
-							}
-							if (invoker.WeaponStatus[DSDProp_Battery] >= 1)
-							{
-								A_UpdateStorage();
-								StorageItem selItem = invoker.Storage.GetSelectedItem();
-								if (selItem)
-								{
-									int inserted = invoker.Storage.TryInsertItem(selItem.InvRef, self, invoker.OperationAmount);
-									invoker.RepeatTics = invoker.Storage.GetOperationSpeed(selItem.ItemClass, SIIAct_Insert);
-									if (inserted > 0)
-									{
-										invoker.WeaponStatus[DSDProp_Battery] -= 1;
-									}
-								}
-							}
-						}
-						else if (PressingUnload())
-						{
-							if (PressingUse())
-							{
-								if (invoker.WeaponStatus[DSDProp_Battery] > -1)
-								{
-									SetWeaponState('RemoveBattery');
-								}
-								return;
-							}
-							if (invoker.WeaponStatus[DSDProp_Battery] >= 1)
-							{
-								A_UpdateStorage();
-								StorageItem selItem = invoker.Storage.GetSelectedItem();
-								if (selItem)
-								{
-									Inventory removed = invoker.Storage.RemoveItem(selItem, self, null, invoker.OperationAmount);
-									invoker.RepeatTics = invoker.Storage.GetOperationSpeed(selItem.ItemClass, SIIAct_Extract);
-									if (removed)
-									{
-										invoker.WeaponStatus[DSDProp_Battery] -= 1;
-									}
-								}
-							}
-						}
-					}
-				}
-			}
+			TNT1 A 1 A_DSDReady();
 			Goto ReadyEnd;
 		RemoveBattery:
 			TNT1 A 20;


### PR DESCRIPTION
- Magazines that use the "Recast" or alternate round type mechanic should now display the proper count, at least the `HD7mMag` and `HD_CAWSMag` and their child classes so far.
- Localized more of the DSD text, similar to how the Backpack handles theirs.
- Organized the classes to make comparing them against the backpack class easier in the future
- Fixed issue where empty magazines could be inserted, but not removed from the DSD.

Fixes #27.